### PR TITLE
[update] 設定を分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+auth.bat

--- a/README.md
+++ b/README.md
@@ -17,24 +17,21 @@ Backlogからプロジェクトをエクスポートする
 
 :warning: 各ファイルがSJISになっていることを確認！
 
-exportBacklog.ps1
+`_auth.bat`を`auth.bat`にリネームし、
 
-```
-# BacklogのAPI
-$BACKLOG_API = "https://spaceId.backlog.jp/api/v2"
-# バックアップしたいプロジェクトキー
-$PROJECT_KEY = "projectId"
-# BacklogのAPIキー
-$API_KEY = "backlogApiKey"
-# バックアップの出力先
-$OUTPUT_DIR = "output"
+```bat
+set API_KEY=xxxxxxxxxxxxxxxx
 ```
 
-あたりをいい感じに調整し、export.batを実行する
+部分を実際のAPIキーに変更し以下のコマンドを実行
+
+```bat
+export.bat スペースID プロジェクトKey 出力ディレクトリ
+```
 
 ## 実行結果
 
-`$OUTPUT_DIR`で指定したディレクトリに以下のように出力される
+出力ディレクトリで指定したディレクトリに以下のように出力される
 
 - Wiki：`PROJECT_KEY\wiki`
 - 課題：`PROJECT_KEY\issue`

--- a/_auth.bat
+++ b/_auth.bat
@@ -1,0 +1,2 @@
+rem BacklogÇÃAPIÉLÅ[
+set API_KEY=xxxxxxxxxxxxxxxx

--- a/export.bat
+++ b/export.bat
@@ -1,5 +1,19 @@
+@echo off
+setlocal
+
+rem パラメタの読み込み
+set spaceId=%1
+set projectKey=%2
+rem src以下で実行するので出力ディレクトリは1階層上げておく
+set outputDir=..\%3
+
+rem APIキーの読み込み
+call auth.bat
+
 cd src
 powershell Set-ExecutionPolicy RemoteSigned
-powershell .\backlogExport.ps1
+powershell .\backlogExport.ps1 %spaceId% %projectKey% %API_KEY% %outputDir%
 powershell Set-ExecutionPolicy Restricted
 cd ..\
+endlocal
+@echo on

--- a/src/backlogExport.ps1
+++ b/src/backlogExport.ps1
@@ -1,3 +1,5 @@
+Param($spaceId, $projectKey, $apiKey, $outputDir)
+
 # TLS1.2に切り替える
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
 
@@ -6,25 +8,23 @@
 . ".\exportIssue.ps1"
 . ".\exportFile.ps1"
 
-# BacklogのAPI
-$BACKLOG_API = "https://spaceId.backlog.jp/api/v2"
-# バックアップしたいプロジェクトキー
-$PROJECT_KEY = "projectId"
-# BacklogのAPIキー
-$API_KEY = "backlogApiKey"
-# バックアップの出力先
-$OUTPUT_DIR = "output"
+# BacklogAPIのURL
+$BACKLOG_API = "https://${spaceId}.backlog.jp/api/v2"
 
 # バックアップの出力ディレクトリを作成
-if (!(Test-Path $OUTPUT_DIR)) {
-    New-Item $OUTPUT_DIR -ItemType Directory | Out-Null
+if (!(Test-Path $outputDir)) {
+    New-Item $outputDir -ItemType Directory | Out-Null
 }
-# 出力ディレクトリに移動
-Set-Location .\output
 
-Export-Wiki $BACKLOG_API $PROJECT_KEY $API_KEY
-Export-Issue $BACKLOG_API $PROJECT_KEY $API_KEY
-Export-File $BACKLOG_API $PROJECT_KEY $API_KEY
+# 現在のディレクトリを取得
+$currentDir = [System.IO.Directory]::GetCurrentDirectory()
+
+# 出力ディレクトリに移動
+Set-Location $outputDir
+
+Export-Wiki $BACKLOG_API $projectKey $apiKey
+Export-Issue $BACKLOG_API $projectKey $apiKey
+Export-File $BACKLOG_API $projectKey $apiKey
 
 # 出力ディレクトリから元のディレクトリに戻る
-Set-Location ..\
+Set-Location $currentDir


### PR DESCRIPTION
- APIキーをauth.batからの読み込みに変更(サンプルとして `_auth.bat` を追加し、 `auth.bat` は `.gitignore` に登録)
- BacklogのスペースID、対象プロジェクト、出力ディレクトリはexport.batの引数として受けるように変更